### PR TITLE
Release for v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v0.3.0](https://github.com/shsk000/NanoType-JP/compare/v0.2.5...v0.3.0) - 2024-11-26
+- feat: error周りのリファクタ by @shsk000 in https://github.com/shsk000/NanoType-JP/pull/35
+- feat: 拗音の抜け修正 by @shsk000 in https://github.com/shsk000/NanoType-JP/pull/37
+
 ## [v0.2.5](https://github.com/shsk000/NanoType-JP/compare/v0.2.4...v0.2.5) - 2024-11-26
 - feat: update tagpr actions by @shsk000 in https://github.com/shsk000/NanoType-JP/pull/33
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shsk002/nano-type-jp",
-  "version": "0.2.5",
+  "version": "0.3.0",
   "type": "module",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This pull request is for the next release as v0.3.0 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.3.0 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.2.5" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* feat: error周りのリファクタ by @shsk000 in https://github.com/shsk000/NanoType-JP/pull/35
* feat: 拗音の抜け修正 by @shsk000 in https://github.com/shsk000/NanoType-JP/pull/37


**Full Changelog**: https://github.com/shsk000/NanoType-JP/compare/v0.2.5...v0.3.0