### PR TITLE
Release for v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v0.4.0](https://github.com/shsk000/NanoType-JP/compare/v0.3.2...v0.4.0) - 2024-11-28
+- feat: add readme by @shsk000 in https://github.com/shsk000/NanoType-JP/pull/42
+
 ## [v0.3.2](https://github.com/shsk000/NanoType-JP/compare/v0.3.1...v0.3.2) - 2024-11-28
 - feat: fix typo by @shsk000 in https://github.com/shsk000/NanoType-JP/pull/40
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shsk002/nano-type-jp",
   "license": "MIT",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "type": "module",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This pull request is for the next release as v0.4.0 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.4.0 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.3.2" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* feat: add readme by @shsk000 in https://github.com/shsk000/NanoType-JP/pull/42


**Full Changelog**: https://github.com/shsk000/NanoType-JP/compare/v0.3.2...v0.4.0