### PR TITLE
Release for v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v0.5.0](https://github.com/shsk000/NanoType-JP/compare/v0.4.1...v0.5.0) - 2024-12-01
+- Feature/realtime input by @shsk000 in https://github.com/shsk000/NanoType-JP/pull/46
+- feat: update class file by @shsk000 in https://github.com/shsk000/NanoType-JP/pull/48
+
 ## [v0.4.1](https://github.com/shsk000/NanoType-JP/compare/v0.4.0...v0.4.1) - 2024-11-29
 - feat: update debug tools by @shsk000 in https://github.com/shsk000/NanoType-JP/pull/44
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shsk002/nano-type-jp",
   "license": "MIT",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "type": "module",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This pull request is for the next release as v0.5.0 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.5.0 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.4.1" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Feature/realtime input by @shsk000 in https://github.com/shsk000/NanoType-JP/pull/46
* feat: update class file by @shsk000 in https://github.com/shsk000/NanoType-JP/pull/48


**Full Changelog**: https://github.com/shsk000/NanoType-JP/compare/v0.4.1...v0.5.0