### PR TITLE
feat: answerAlphabet に resolvedUnitCount を追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "nano-type-jp",
-  "version": "0.0.0",
+  "name": "@shsk002/nano-type-jp",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "nano-type-jp",
-      "version": "0.0.0",
+      "name": "@shsk002/nano-type-jp",
+      "version": "0.6.0",
+      "license": "MIT",
       "devDependencies": {
         "typescript": "~5.6.2",
         "vite": "^5.4.10",
@@ -1823,6 +1824,7 @@
       "integrity": "sha512-HBW896xR5HGmoksbi3JBDtmVzWiPAYqp7wip50hjQ67JbDz61nyoMPdqu1DvVW9asYb2M65Z20ZHsyJCMqMyDg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.6"
       },
@@ -2021,6 +2023,7 @@
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2062,6 +2065,7 @@
       "integrity": "sha512-1hvaPshuPUtxeQ0hsVH3Mud0ZanOLwVTneA1EgbAM5LhaZEqyPWGRQ7BtaMvUrTDeEaC8pxtj6a6jku3x4z6SQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/src/typing/nanoTypeJp.test.ts
+++ b/src/typing/nanoTypeJp.test.ts
@@ -87,6 +87,7 @@ describe("typingGame.test.ts", () => {
         correctCount: 1,
         completedCount: 0,
         perfectStreakCount: 0,
+        resolvedUnitCount: 0,
         inputAlphabet: {
           completedInputAlphabet: "k",
           remainedAlphabet: "a",
@@ -105,6 +106,7 @@ describe("typingGame.test.ts", () => {
         correctCount: 2,
         completedCount: 1,
         perfectStreakCount: 1,
+        resolvedUnitCount: 1,
         inputAlphabet: {
           completedInputAlphabet: "ka",
           remainedAlphabet: "",
@@ -124,6 +126,7 @@ describe("typingGame.test.ts", () => {
         correctCount: 1,
         completedCount: 0,
         perfectStreakCount: 0,
+        resolvedUnitCount: 0,
         inputAlphabet: {
           completedInputAlphabet: "k",
           remainedAlphabet: "a",
@@ -137,6 +140,7 @@ describe("typingGame.test.ts", () => {
         correctCount: 2,
         completedCount: 1,
         perfectStreakCount: 1,
+        resolvedUnitCount: 1,
         inputAlphabet: {
           completedInputAlphabet: "ka",
           remainedAlphabet: "",
@@ -149,6 +153,52 @@ describe("typingGame.test.ts", () => {
     test("入力可能なパターンがない場合はエラーを返却する", () => {
       const game = new NanoTypeJp();
       expect(() => game.registerNewHiragana("a")).toThrowError();
+    });
+  });
+
+  describe("resolvedUnitCount（利用側のゲームでの実プレイで見つかった回帰の再現）", () => {
+    test("拗音の代替入力（si+小さいゅ）でも、直接入力（shu）と同じ単位数で完了する", () => {
+      const direct = new NanoTypeJp();
+      direct.registerNewHiragana("しゅうせいをあてる");
+      let r = direct.answerAlphabet("s");
+      expect(r.resolvedUnitCount).toBe(0); // しゅ、まだ未完了
+      r = direct.answerAlphabet("h");
+      r = direct.answerAlphabet("u"); // "shu" でしゅ完了
+      expect(r.resolvedUnitCount).toBe(1);
+
+      const split = new NanoTypeJp();
+      const reg = split.registerNewHiragana("しゅうせいをあてる");
+      expect(reg.totalUnitCount).toBe(8); // しゅ,う,せ,い,を,あ,て,る
+      let r2 = split.answerAlphabet("s");
+      expect(r2.resolvedUnitCount).toBe(0);
+      r2 = split.answerAlphabet("i");
+      expect(r2.resolvedUnitCount).toBe(0); // "si" だけではまだ「しゅ」未完了（小さいゅが残っている）
+      r2 = split.answerAlphabet("l");
+      r2 = split.answerAlphabet("y");
+      r2 = split.answerAlphabet("u"); // "silyu" でしゅ完了
+      expect(r2.resolvedUnitCount).toBe(1);
+    });
+
+    test("じょうたい：zi+小さいょ（l/xプレフィックス）でも、じょ完了で1、うが次", () => {
+      const game = new NanoTypeJp();
+      const reg = game.registerNewHiragana("じょうたいをかんりする");
+      expect(reg.totalUnitCount).toBe(10); // じょ,う,た,い,を,か,ん,り,す,る
+      let r = game.answerAlphabet("z");
+      r = game.answerAlphabet("i");
+      expect(r.resolvedUnitCount).toBe(0); // "zi" だけではじょ未完了
+      r = game.answerAlphabet("l");
+      expect(r.resolvedUnitCount).toBe(0); // 小さいょの途中でも0のまま（オーナー実プレイで見つかった回帰）
+      r = game.answerAlphabet("y");
+      r = game.answerAlphabet("o"); // "zilyo" でじょ完了
+      expect(r.resolvedUnitCount).toBe(1);
+    });
+
+    test("あいで：単独母音（1打鍵で完了する単位）は打った瞬間に1つ進む", () => {
+      const game = new NanoTypeJp();
+      const reg = game.registerNewHiragana("あいであをじっそうする");
+      expect(reg.totalUnitCount).toBe(10); // あ,い,で,あ,を,じ,っそ,う,す,る
+      const r = game.answerAlphabet("a");
+      expect(r.resolvedUnitCount).toBe(1); // 「あ」を打った瞬間に完了（オーナー実プレイで見つかった回帰）
     });
   });
 });

--- a/src/typing/nanoTypeJp.ts
+++ b/src/typing/nanoTypeJp.ts
@@ -20,6 +20,12 @@ type AnswerResult = {
   completedCount: number;
   /** １タイプごと：入力失敗数 */
   perfectStreakCount: number;
+  /**
+   * 何個目の入力単位（モーラ）まで確定したか。totalUnitCount と合わせて使うと、
+   * 拗音の代替入力等で単位あたりの打鍵数が変わっても、外部でローマ字の打鍵数から
+   * 「かな側の今の位置」を近似する必要がなくなる。
+   */
+  resolvedUnitCount: number;
 
   inputAlphabet: InputAlphabetResult;
 };
@@ -27,6 +33,8 @@ type AnswerResult = {
 type RegisterResult = {
   inputAlphabet: InputAlphabetResult;
   inputPattern: TypingPatternResolver[];
+  /** 入力単位（モーラ）の総数。resolvedUnitCount の分母として使う */
+  totalUnitCount: number;
 };
 
 export class NanoTypeJp {
@@ -61,13 +69,15 @@ export class NanoTypeJp {
       );
     }
     const alphabetSentece = this.inputValidator.initialize(parsedHiragana);
+    const inputPattern = this.inputValidator.getTypingPatternResolver();
 
     return {
       inputAlphabet: {
         remainedAlphabet: alphabetSentece,
         completedInputAlphabet: "",
       },
-      inputPattern: this.inputValidator.getTypingPatternResolver(),
+      inputPattern,
+      totalUnitCount: inputPattern.length,
     };
   }
 
@@ -82,6 +92,7 @@ export class NanoTypeJp {
         correctCount: this.correctCount,
         completedCount: this.completedCount,
         perfectStreakCount: this.perfectStreakCount,
+        resolvedUnitCount: response.resolvedUnitCount,
         inputAlphabet: {
           completedInputAlphabet: response.selectedAlphabetSentence.slice(
             0,
@@ -105,6 +116,7 @@ export class NanoTypeJp {
         correctCount: this.correctCount,
         completedCount: this.completedCount,
         perfectStreakCount: this.perfectStreakCount,
+        resolvedUnitCount: response.resolvedUnitCount,
         inputAlphabet: {
           completedInputAlphabet: response.selectedAlphabetSentence.slice(
             0,
@@ -125,6 +137,7 @@ export class NanoTypeJp {
       correctCount: this.correctCount,
       completedCount: this.completedCount,
       perfectStreakCount: this.perfectStreakCount,
+      resolvedUnitCount: response.resolvedUnitCount,
       inputAlphabet: {
         completedInputAlphabet: response.selectedAlphabetSentence.slice(
           0,

--- a/src/typing/realTimeInputValidator.test.ts
+++ b/src/typing/realTimeInputValidator.test.ts
@@ -19,6 +19,7 @@ describe("realTimeInputValidator.test.ts", () => {
       result: "correct",
       correctLength: 1,
       selectedAlphabetSentence: "aiu",
+      resolvedUnitCount: 1,
     });
 
     const result2 = validator.input("i");
@@ -26,6 +27,7 @@ describe("realTimeInputValidator.test.ts", () => {
       result: "correct",
       correctLength: 2,
       selectedAlphabetSentence: "aiu",
+      resolvedUnitCount: 2,
     });
 
     // ミス
@@ -34,6 +36,7 @@ describe("realTimeInputValidator.test.ts", () => {
       result: "fail",
       correctLength: 2,
       selectedAlphabetSentence: "aiu",
+      resolvedUnitCount: 2,
     });
 
     const result4 = validator.input("u");
@@ -41,6 +44,7 @@ describe("realTimeInputValidator.test.ts", () => {
       result: "complete",
       correctLength: 3,
       selectedAlphabetSentence: "aiu",
+      resolvedUnitCount: 3,
     });
   });
 
@@ -57,38 +61,45 @@ describe("realTimeInputValidator.test.ts", () => {
       result: "correct",
       correctLength: 1,
       selectedAlphabetSentence: "sasisu",
+      resolvedUnitCount: 0,
     });
     // ミス
     expect(validator.input("x")).toEqual({
       result: "fail",
       correctLength: 1,
       selectedAlphabetSentence: "sasisu",
+      resolvedUnitCount: 0,
     });
     expect(validator.input("a")).toEqual({
       result: "correct",
       correctLength: 2,
       selectedAlphabetSentence: "sasisu",
+      resolvedUnitCount: 1,
     });
     // sではなくcを入力してパターンを変更する
     expect(validator.input("c")).toEqual({
       result: "correct",
       correctLength: 3,
       selectedAlphabetSentence: "sacisu",
+      resolvedUnitCount: 1,
     });
     expect(validator.input("i")).toEqual({
       result: "correct",
       correctLength: 4,
       selectedAlphabetSentence: "sacisu",
+      resolvedUnitCount: 2,
     });
     expect(validator.input("s")).toEqual({
       result: "correct",
       correctLength: 5,
       selectedAlphabetSentence: "sacisu",
+      resolvedUnitCount: 2,
     });
     expect(validator.input("u")).toEqual({
       result: "complete",
       correctLength: 6,
       selectedAlphabetSentence: "sacisu",
+      resolvedUnitCount: 3,
     });
   });
 
@@ -102,52 +113,62 @@ describe("realTimeInputValidator.test.ts", () => {
       result: "correct",
       correctLength: 1,
       selectedAlphabetSentence: "pakkyao",
+      resolvedUnitCount: 0,
     });
     expect(validator.input("a")).toEqual({
       result: "correct",
       correctLength: 2,
       selectedAlphabetSentence: "pakkyao",
+      resolvedUnitCount: 1,
     });
     expect(validator.input("k")).toEqual({
       result: "correct",
       correctLength: 3,
       selectedAlphabetSentence: "pakkyao",
+      resolvedUnitCount: 1,
     });
     expect(validator.input("k")).toEqual({
       result: "correct",
       correctLength: 4,
       selectedAlphabetSentence: "pakkyao",
+      resolvedUnitCount: 1,
     });
     expect(validator.input("i")).toEqual({
       result: "correct",
       correctLength: 5,
       selectedAlphabetSentence: "pakkilyao",
+      resolvedUnitCount: 1,
     });
     // ミス
     expect(validator.input("i")).toEqual({
       result: "fail",
       correctLength: 5,
       selectedAlphabetSentence: "pakkilyao",
+      resolvedUnitCount: 1,
     });
     expect(validator.input("x")).toEqual({
       result: "correct",
       correctLength: 6,
       selectedAlphabetSentence: "pakkixyao",
+      resolvedUnitCount: 1,
     });
     expect(validator.input("y")).toEqual({
       result: "correct",
       correctLength: 7,
       selectedAlphabetSentence: "pakkixyao",
+      resolvedUnitCount: 1,
     });
     expect(validator.input("a")).toEqual({
       result: "correct",
       correctLength: 8,
       selectedAlphabetSentence: "pakkixyao",
+      resolvedUnitCount: 2,
     });
     expect(validator.input("o")).toEqual({
       result: "complete",
       correctLength: 9,
       selectedAlphabetSentence: "pakkixyao",
+      resolvedUnitCount: 3,
     });
   });
 });

--- a/src/typing/realTimeInputValidator.ts
+++ b/src/typing/realTimeInputValidator.ts
@@ -5,6 +5,13 @@ type InputResult = {
   result: "correct" | "fail" | "complete";
   correctLength: number;
   selectedAlphabetSentence: string;
+  /**
+   * 何個目のTypingPatternResolver（入力単位＝モーラ）まで確定したか。
+   * 拗音の代替入力（例：しゅ＝shu/syuの直接入力 と si+小さいゅ の分割入力）等、
+   * 単位あたりの打鍵数が変わるパターンでも、確定した単位の「個数」は常に正確。
+   * かな表示のハイライト等、外部から「何文字目まで進んだか」を打鍵数から近似する必要をなくす。
+   */
+  resolvedUnitCount: number;
 };
 
 export class RealTimeInputValidator {
@@ -38,6 +45,11 @@ export class RealTimeInputValidator {
     return this.typingPatternResolvers;
   }
 
+  /** 何個目のTypingPatternResolver（入力単位＝モーラ）まで確定したか */
+  public getResolvedUnitCount() {
+    return this.targetTypingPatternResolverNumber;
+  }
+
   public initialize(typingUnits: TypingUnits): string {
     this.typingPatternResolvers =
       this.patternUntisToPatternResolvers(typingUnits);
@@ -62,6 +74,7 @@ export class RealTimeInputValidator {
           result: "correct",
           correctLength: this.correctLength,
           selectedAlphabetSentence: this.createToSelectedAlphabetSentence(),
+          resolvedUnitCount: this.targetTypingPatternResolverNumber,
         };
       case "complete":
         this.correctLength++;
@@ -73,18 +86,21 @@ export class RealTimeInputValidator {
             result: "complete",
             correctLength: this.correctLength,
             selectedAlphabetSentence: this.createToSelectedAlphabetSentence(),
+            resolvedUnitCount: this.targetTypingPatternResolverNumber,
           };
         }
         return {
           result: "correct",
           correctLength: this.correctLength,
           selectedAlphabetSentence: this.createToSelectedAlphabetSentence(),
+          resolvedUnitCount: this.targetTypingPatternResolverNumber,
         };
       case "fail":
         return {
           result: "fail",
           correctLength: this.correctLength,
           selectedAlphabetSentence: this.createToSelectedAlphabetSentence(),
+          resolvedUnitCount: this.targetTypingPatternResolverNumber,
         };
     }
   }


### PR DESCRIPTION
## Summary
- 利用側ゲーム（typing-factory）で「入力中のかな表示」の現在位置をローマ字打鍵数から外部で近似していたが、拗音の代替入力パターン（例：しゅ＝shu/syu の直接入力 と si+小さいゅ の分割入力）等、1モーラに複数の正当な打鍵数パターンが存在するため、近似が3種類の実プレイで立て続けに破綻した
- `RealTimeInputValidator` が内部で持つ `targetTypingPatternResolverNumber`（現在処理中の入力単位＝モーラの添字）をそのまま公開する
  - `RealTimeInputValidator.getResolvedUnitCount()` を追加。`input()` の返り値に `resolvedUnitCount` を含める
  - `NanoTypeJp.answerAlphabet()` の `AnswerResult` に `resolvedUnitCount`、`registerNewHiragana()` の `RegisterResult` に `totalUnitCount` を追加
- 利用側は `resolvedUnitCount / totalUnitCount` をそのまま使え、打鍵数からの近似が不要になる

## Test plan
- [x] 既存テスト（新フィールド追加に伴う `toEqual`/`toStrictEqual` 更新）含め全307件緑
- [x] 実際に見つかった3つの回帰（si+lyu、zi+lyo、単独母音「あ」）をそのまま unit テストとして追加し、期待値が実装と一致することを確認
- [x] `npm run build` 成功、`dist/*.d.ts` に新フィールドが出力されることを確認