### PR TITLE
fix: CI廃止済みactionsのバージョン更新・lockファイル復元

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -20,12 +20,12 @@ jobs:
         run: |
           npm install && npm run build:debug
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist
 
-      - uses: actions/upload-pages-artifact@v1
+      - uses: actions/upload-pages-artifact@v3
         with:
           path: dist
 
@@ -39,5 +39,5 @@ jobs:
       pages: write
       id-token: write
     steps:
-      - uses: actions/deploy-pages@v1
+      - uses: actions/deploy-pages@v4
         id: deployment

--- a/.github/workflows/tagpr.yaml
+++ b/.github/workflows/tagpr.yaml
@@ -12,7 +12,7 @@ jobs:
     outputs:
       tagpr-tag: ${{ steps.run-tagpr.outputs.tag }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GH_PAT }}
       - uses: Songmu/tagpr@main

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,12 @@
 {
-  "name": "@shsk002/nano-type-jp",
-  "version": "0.6.0",
+  "name": "nano-type-jp",
+  "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@shsk002/nano-type-jp",
-      "version": "0.6.0",
-      "license": "MIT",
+      "name": "nano-type-jp",
+      "version": "0.0.0",
       "devDependencies": {
         "typescript": "~5.6.2",
         "vite": "^5.4.10",
@@ -1824,7 +1823,6 @@
       "integrity": "sha512-HBW896xR5HGmoksbi3JBDtmVzWiPAYqp7wip50hjQ67JbDz61nyoMPdqu1DvVW9asYb2M65Z20ZHsyJCMqMyDg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.6"
       },
@@ -2023,7 +2021,6 @@
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2065,7 +2062,6 @@
       "integrity": "sha512-1hvaPshuPUtxeQ0hsVH3Mud0ZanOLwVTneA1EgbAM5LhaZEqyPWGRQ7BtaMvUrTDeEaC8pxtj6a6jku3x4z6SQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",


### PR DESCRIPTION
## Summary
- Debug HTML Deploy が `actions/upload-artifact@v3`（GitHub側で完全廃止済み）で失敗していたため v4 に更新。合わせて `upload-pages-artifact@v1`→v3、`deploy-pages@v1`→v4 に更新
- Tagpr が `actions/checkout@v3` で認証エラー（`terminal prompts disabled`）を起こしていたため、他のワークフロー（test/publish）と同じ v4 に統一
- 前PR（#51）で `npm install` 実行時に package-lock.json の name/version が package.json 側（`@shsk002/nano-type-jp@0.6.0`）に同期されてしまっていたが、tagpr がバージョン管理する運用のため不要な変更だった。`nano-type-jp@0.0.0` に戻す

## Test plan
- [x] `npm test` 307件緑
- [x] `npm run build` 成功