### PR TITLE
Release for v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v0.7.0](https://github.com/shsk000/NanoType-JP/compare/v0.6.0...v0.7.0) - 2026-07-12
+
+- feat: answerAlphabet に resolvedUnitCount を追加 by @shsk000 in https://github.com/shsk000/NanoType-JP/pull/51
+- fix: CI廃止済みactionsのバージョン更新・lockファイル復元 by @shsk000 in https://github.com/shsk000/NanoType-JP/pull/52
+
 ## [v0.6.0](https://github.com/shsk000/NanoType-JP/compare/v0.5.0...v0.6.0) - 2024-12-02
 - fix: symbolsのタイプ情報に半角文字を渡すように調整 by @shsk000 in https://github.com/shsk000/NanoType-JP/pull/49
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shsk002/nano-type-jp",
   "license": "MIT",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "type": "module",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This pull request is for the next release as v0.7.0 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.7.0 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.6.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* feat: answerAlphabet に resolvedUnitCount を追加 by @shsk000 in https://github.com/shsk000/NanoType-JP/pull/51
* fix: CI廃止済みactionsのバージョン更新・lockファイル復元 by @shsk000 in https://github.com/shsk000/NanoType-JP/pull/52


**Full Changelog**: https://github.com/shsk000/NanoType-JP/compare/v0.6.0...tagpr-from-v0.6.0