### PR TITLE
Release for v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v0.8.0](https://github.com/shsk000/NanoType-JP/compare/v0.7.0...v0.8.0) - 2026-07-31
+
+- fix: 外来音（ふぇ=fe など）のローマ字入力パターンを整備 by @shsk000 in https://github.com/shsk000/NanoType-JP/pull/54
+
 ## [v0.7.0](https://github.com/shsk000/NanoType-JP/compare/v0.6.0...v0.7.0) - 2026-07-12
 
 - feat: answerAlphabet に resolvedUnitCount を追加 by @shsk000 in https://github.com/shsk000/NanoType-JP/pull/51

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shsk002/nano-type-jp",
   "license": "MIT",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "type": "module",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This pull request is for the next release as v0.8.0 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.8.0 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.7.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* fix: 外来音（ふぇ=fe など）のローマ字入力パターンを整備 by @shsk000 in https://github.com/shsk000/NanoType-JP/pull/54


**Full Changelog**: https://github.com/shsk000/NanoType-JP/compare/v0.7.0...tagpr-from-v0.7.0